### PR TITLE
v1.5.3 - Add ability to get postals server sided from vec3

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,7 +12,7 @@ lua54 "yes"
 
 author 'DevBlocky'
 description 'This script displays the nearest postal next to map, and allows you to navigate to specific postal codes'
-version '1.5.2'
+version '1.5.3'
 url 'https://github.com/DevBlocky/nearest-postal'
 
 client_scripts {
@@ -35,3 +35,5 @@ file(postalFile)
 postal_file(postalFile)
 
 file 'version.json'
+
+server_export 'getPostalServer'

--- a/sv.lua
+++ b/sv.lua
@@ -1,24 +1,59 @@
 -- version check
 Citizen.CreateThread(function()
-    local vRaw = LoadResourceFile(GetCurrentResourceName(), 'version.json')
-    if vRaw and config.versionCheck then
-        local v = json.decode(vRaw)
-        local url = 'https://raw.githubusercontent.com/DevBlocky/nearest-postal/master/version.json'
-        PerformHttpRequest(url, function(code, res)
-            if code == 200 then
-                local rv = json.decode(res)
-                if rv.version ~= v.version then
-                    print(([[
+	local vRaw = LoadResourceFile(GetCurrentResourceName(), 'version.json')
+	if vRaw and config.versionCheck then
+		local v = json.decode(vRaw)
+		local url = 'https://raw.githubusercontent.com/DevBlocky/nearest-postal/master/version.json'
+		PerformHttpRequest(url, function(code, res)
+			if code == 200 then
+				local rv = json.decode(res)
+				if rv.version ~= v.version then
+					print(([[
 -------------------------------------------------------
 nearest-postal
 UPDATE: %s AVAILABLE
 CHANGELOG: %s
 -------------------------------------------------------
 ]]):format(rv.version, rv.changelog))
-                end
-            else
-                print('nearest-postal was unable to check the version')
-            end
-        end, 'GET')
-    end
+				end
+			else
+				print('nearest-postal was unable to check the version')
+			end
+		end, 'GET')
+	end
+end)
+
+-- add functionality to get postals server side from a vec3
+
+local postals = nil
+Citizen.CreateThread(function()
+	postals = LoadResourceFile(GetCurrentResourceName(), GetResourceMetadata(GetCurrentResourceName(), 'postal_file'))
+	postals = json.decode(postals)
+	for i, postal in ipairs(postals) do
+		postals[i] = {vec(postal.x, postal.y), code = postal.code}
+	end
+end)
+
+local function getPostalServer(coords)
+	while postals == nil do
+		Wait(1)
+	end
+	local _total = #postals
+	local _nearestIndex, _nearestD
+	coords = vec(coords[1], coords[2])
+
+	for i = 1, _total do
+		local D = #(coords - postals[i][1])
+		if not _nearestD or D < _nearestD then
+			_nearestIndex = i
+			_nearestD = D
+		end
+	end
+	local _code = postals[_nearestIndex].code
+	local nearest = {code = _code, dist = _nearestD}
+	return nearest or nil
+end
+
+exports('getPostalServer', function(coords)
+	return getPostalServer(coords)
 end)

--- a/sv.lua
+++ b/sv.lua
@@ -1,59 +1,59 @@
 -- version check
 Citizen.CreateThread(function()
-	local vRaw = LoadResourceFile(GetCurrentResourceName(), 'version.json')
-	if vRaw and config.versionCheck then
-		local v = json.decode(vRaw)
-		local url = 'https://raw.githubusercontent.com/DevBlocky/nearest-postal/master/version.json'
-		PerformHttpRequest(url, function(code, res)
-			if code == 200 then
-				local rv = json.decode(res)
-				if rv.version ~= v.version then
-					print(([[
+    local vRaw = LoadResourceFile(GetCurrentResourceName(), 'version.json')
+    if vRaw and config.versionCheck then
+        local v = json.decode(vRaw)
+        local url = 'https://raw.githubusercontent.com/DevBlocky/nearest-postal/master/version.json'
+        PerformHttpRequest(url, function(code, res)
+            if code == 200 then
+                local rv = json.decode(res)
+                if rv.version ~= v.version then
+                    print(([[
 -------------------------------------------------------
 nearest-postal
 UPDATE: %s AVAILABLE
 CHANGELOG: %s
 -------------------------------------------------------
 ]]):format(rv.version, rv.changelog))
-				end
-			else
-				print('nearest-postal was unable to check the version')
-			end
-		end, 'GET')
-	end
+                end
+            else
+                print('nearest-postal was unable to check the version')
+            end
+        end, 'GET')
+    end
 end)
 
 -- add functionality to get postals server side from a vec3
 
 local postals = nil
 Citizen.CreateThread(function()
-	postals = LoadResourceFile(GetCurrentResourceName(), GetResourceMetadata(GetCurrentResourceName(), 'postal_file'))
-	postals = json.decode(postals)
-	for i, postal in ipairs(postals) do
-		postals[i] = {vec(postal.x, postal.y), code = postal.code}
-	end
+    postals = LoadResourceFile(GetCurrentResourceName(), GetResourceMetadata(GetCurrentResourceName(), 'postal_file'))
+    postals = json.decode(postals)
+    for i, postal in ipairs(postals) do
+        postals[i] = {vec(postal.x, postal.y), code = postal.code}
+    end
 end)
 
 local function getPostalServer(coords)
-	while postals == nil do
-		Wait(1)
-	end
-	local _total = #postals
-	local _nearestIndex, _nearestD
-	coords = vec(coords[1], coords[2])
+    while postals == nil do
+        Wait(1)
+    end
+    local _total = #postals
+    local _nearestIndex, _nearestD
+    coords = vec(coords[1], coords[2])
 
-	for i = 1, _total do
-		local D = #(coords - postals[i][1])
-		if not _nearestD or D < _nearestD then
-			_nearestIndex = i
-			_nearestD = D
-		end
-	end
-	local _code = postals[_nearestIndex].code
-	local nearest = {code = _code, dist = _nearestD}
-	return nearest or nil
+    for i = 1, _total do
+        local D = #(coords - postals[i][1])
+        if not _nearestD or D < _nearestD then
+            _nearestIndex = i
+            _nearestD = D
+        end
+    end
+    local _code = postals[_nearestIndex].code
+    local nearest = {code = _code, dist = _nearestD}
+    return nearest or nil
 end
 
 exports('getPostalServer', function(coords)
-	return getPostalServer(coords)
+    return getPostalServer(coords)
 end)

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-	"version": "1.5.2",
+	"version": "1.5.3",
 	"changelog": "Bugfixes and performance improvements"
 }

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
 	"version": "1.5.3",
-	"changelog": "Bugfixes and performance improvements"
+	"changelog": "Add ability to get postals from vec3 server sided"
 }


### PR DESCRIPTION
## Overview
This commit adds the export `getPostalServer`, which takes a vec3 as a parameter, it then returns a Lua table containing the following data:
| parameter | type | description |
--- |--- | ---------- |
| code | string | the nearest postal code to the provided coords |
| dist | int | the exact distance the coords are from the postal 

#### Example Usage
```lua
local postal = exports['nearest-postal']:getPostalServer({91.6690, -1944.38, 22.952})
print('postal from server: ', json.encode(postal))
```
__Expected print:__
`postal from server: 	{"dist":34.63740158081055,"code":"9103"}`