### PR TITLE
feat(sv.lua): Added functionality to capture coords and create new postals.

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -46,4 +46,6 @@ config = {
     -- How often in milliseconds the postal code is updated on each client.
     -- I wouldn't recommend anything lower than 50ms for performance reasons
     updateDelay = nil,
+
+    useEsx = GetResourceState("es_extended") ~= "missing",
 }

--- a/sv.lua
+++ b/sv.lua
@@ -57,3 +57,38 @@ end
 exports('getPostalServer', function(coords)
     return getPostalServer(coords)
 end)
+
+if config.useEsx then
+    ESX = exports["es_extended"]:getSharedObject()
+
+    local currentPositions = LoadResourceFile(GetCurrentResourceName(), GetResourceMetadata(GetCurrentResourceName(), 'postal_file'))
+    local currentPositions = json.decode(currentPositions)
+
+    ESX.RegisterCommand('plog', 'admin', function(xPlayer, args, showError)
+        local coords = xPlayer.getCoords(false)
+
+        if not args.postal then print('A postal is required!') return end
+        
+        postNum = tonumber(args.postal)
+
+        if (postNum >= 1) and (postNum <= 9) then
+            tostring(postNum)
+            postal = '00' .. postNum
+        elseif (postNum >= 10) and (postNum <= 99) then
+            tostring(postNum)
+            postal = '0' .. postNum
+        elseif postNum >= 100 then
+            tostring(postNum)
+            postal = postNum
+        end
+        
+        convPostal = tostring(postal)
+
+        currentPositions[#currentPositions + 1] = {code = convPostal, x = coords.x, y = coords.y}
+        SaveResourceFile(GetCurrentResourceName(), "postals.json", json.encode(currentPositions), -1)
+        print("^5[Obtain Position]^7 ^2Successfully saved positions to JSON file!^7")
+        print(("^3[Postals Saved!] Postal: %s | X: %s, Y: %s^7"):format(convPostal, coords.x, coords.y))
+        print("^5[File Backup]^7 ^2Be sure to backup your postals.json file before the next server restart to save your work!^7")
+
+    end, false, {help = 'Captures and stores postal with X/Y coords in a table.', arguments = {{name = 'postal', help = 'Postal for captured coordinates', type = 'any'}}})    
+end


### PR DESCRIPTION
Added the functionality to allow players to add postals using the command `/plog <postal>`. If the developer is using a map that is not included with nearest-postal, they will need to create a blank JSON file and update the `postalFile` variable in `fxmanifest.lua` with the new file name prior to using this functionality.

When using the `/plog` command, the player will not need to add the full three-digit postal. They will only need to type (as an example) `/plog 1` and the resource will pad the postal to save as `001`. It does this by converting the postal input to an integer, checking if it is between 1 and 99, converting back to a string and padding with leading zeroes.

This does create a dependency on ESX only if the player wishes to use this functionality, otherwise if the player is using an alternate or no framework this functionality will not be enabled. I've added a config option to `config.lua` which will check to see if `es_extended` (the name for the ESX core resource) has started and wrapped the new code in an `if config.useEsx then` statement. It will also only allow players with `group.admin` permissions to use the command.