### PR TITLE
Allow other resources to set/clear postal route

### DIFF
--- a/cl.lua
+++ b/cl.lua
@@ -20,3 +20,4 @@ nearest = nil
 pBlip = nil
 
 exports('getPostal', function() return nearest and nearest.code or nil end)
+exports('setDirections', function(postal) SetRouteToPostal(postal) end)

--- a/cl_commands.lua
+++ b/cl_commands.lua
@@ -8,11 +8,8 @@ local format = string.format
 --- [[ Nearest Postal Commands ]] ---
 ---
 
-TriggerEvent('chat:addSuggestion', '/postal', 'Set the GPS to a specific postal',
-             { { name = 'Postal Code', help = 'The postal code you would like to go to' } })
-
-RegisterCommand('postal', function(_, args)
-    if #args < 1 then
+function SetRouteToPostal(postal)
+    if not postal then
         if pBlip then
             RemoveBlip(pBlip.hndl)
             pBlip = nil
@@ -27,7 +24,7 @@ RegisterCommand('postal', function(_, args)
         return
     end
 
-    local userPostal = upper(args[1])
+    local userPostal = upper(postal)
     local foundPostal
 
     for _, p in ipairs(postals) do
@@ -65,5 +62,12 @@ RegisterCommand('postal', function(_, args)
             }
         })
     end
+end
+
+TriggerEvent('chat:addSuggestion', '/postal', 'Set the GPS to a specific postal',
+             { { name = 'Postal Code', help = 'The postal code you would like to go to' } })
+
+RegisterCommand('postal', function(_, args)
+    SetRouteToPostal(args[1])
 end)
 


### PR DESCRIPTION
This PR allows other resources to essentially "execute" the /postal command, via an export.

It achieves this by extrapolating the /postal logic out into a function and adding an export that calls that function, while replacing the postal logic with a call to that new function.

This PR *should* be compatible with my other PR, but let me know if you have any trouble merging and i'll happily resolve any conflicts my branch has.